### PR TITLE
Simplifies ParamExtractor get_parameters() method with RegExp

### DIFF
--- a/seleniumactions/elements.py
+++ b/seleniumactions/elements.py
@@ -1,4 +1,5 @@
 import logging, sys
+import re
 from abc import ABC, abstractmethod
 from typing import List, Optional, Tuple
 
@@ -31,22 +32,16 @@ class ParameterExtractor:
         self.__text = text
 
     def get_parameters(self) -> List[str]:
-        # todo: refactor ?
-        params = []
-        param, last_index = self.__find_param(start_index=0)
-        while param is not None and last_index > -1:
-            params.append(param)
-            param, last_index = self.__find_param(start_index=last_index)
-        return params
+        pattern = r'{\w+}'
 
-    def __find_param(self, start_index: int) -> Tuple[Optional[str], int]:
-        open = self.__text.find('{', start_index)
-        close = self.__text.find('}', start_index + 1)
-        if open == -1 or close == -1:
-            return None, -1
-        if open > close:
-            return None, -1
-        return self.__text[open + 1:close], close
+        if params := re.findall(pattern, self.__text):
+            return self.__extract_params(params)
+
+        return []
+
+    @staticmethod
+    def __extract_params(params: List[str]) -> List[str]:
+        return [re.sub(r'[{}]', '', param) for param in params]
 
 
 class Locator:

--- a/tests/parameter_extractor_test.py
+++ b/tests/parameter_extractor_test.py
@@ -34,6 +34,20 @@ class ParameterExtractorTest(unittest.TestCase):
         assert 'faz' in params
         assert 'gaz' in params
 
+    def test_extract_param_empty_string(self):
+        text = ''
+        e = ParameterExtractor(text)
+        params = e.get_parameters()
+        assert len(params) == 0
+
+    def test_extract_nested_params(self):
+        text = '/foo[@bar="{{baz}}-{faz}{gaz}"]'
+        e = ParameterExtractor(text)
+        params = e.get_parameters()
+        assert len(params) == 3
+        assert ['baz', 'faz', 'gaz'] == params
+
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Hi! I've been using your library from quite some time and was wondering if I could contribute with something. I have an idea which would simplify an area of your code (marked as #TODO). 

So I've noticed that ParameterExtractor  -> get_parameters() contains a logic for parsing `'{param}'` from the input xpath string. I've manage to get this effect using regular expressions. All tests are passing, I've also added 2 new ones.

Looking forward for your feedback.
